### PR TITLE
Enable first paginator button when results have an offset.

### DIFF
--- a/src/Service/File/LogParser.php
+++ b/src/Service/File/LogParser.php
@@ -41,9 +41,10 @@ class LogParser
             $index->addLine($logLine);
         }
 
-        // stream reader didn't reach the end
-        if ($lineIterator->isEOF() === false) {
-            $index->setPaginator(new Paginator($logQuery->direction, $logQuery->offset === null, true, $lineIterator->getPosition()));
+        // create paginator
+        $hasOffset = (int)$logQuery->offset > 0;
+        if ($lineIterator->isEOF() === false || $hasOffset) {
+            $index->setPaginator(new Paginator($logQuery->direction, $hasOffset, $lineIterator->isEOF() === false, $lineIterator->getPosition()));
         }
 
         return $index;

--- a/tests/Integration/Service/File/LogParserTest.php
+++ b/tests/Integration/Service/File/LogParserTest.php
@@ -95,9 +95,19 @@ class LogParserTest extends AbstractIntegrationTestCase
         static::assertNotNull($index->getPaginator());
     }
 
+    public function testParsePaginatorWithOffset(): void
+    {
+        $query = new LogQueryDto('identifier', 5, '', DirectionEnum::Asc, null, null, 500);
+        $file  = new SplFileInfo($this->getResourcePath('Integration/Service/LogParser/monolog.log'), '', '');
+        $index = $this->parser->parse($file, $this->lineParser, $query);
+
+        static::assertCount(99, $index->getLines());
+        static::assertNotNull($index->getPaginator());
+    }
+
     public function testParseEof(): void
     {
-        $query = new LogQueryDto('identifier', 0, '', DirectionEnum::Asc, null, null, 500);
+        $query = new LogQueryDto('identifier', null, '', DirectionEnum::Asc, null, null, 500);
         $file  = new SplFileInfo($this->getResourcePath('Integration/Service/LogParser/monolog.log'), '', '');
         $index = $this->parser->parse($file, $this->lineParser, $query);
 


### PR DESCRIPTION
When using the paginator, naviging to page 2, the `first` is disabled when the eof is reached.