### PR TITLE
Add support for searching context and extra

### DIFF
--- a/docs/advanced-search-queries.md
+++ b/docs/advanced-search-queries.md
@@ -45,6 +45,7 @@ before:"2020-01-31 23:59:59" after:"2020-01-01 00:00:00" exclude:"new IndexContr
 
 ### Searching context or extra
 
+Matches if at least one of the array values contains the given string:
 ```text
 context:foo
 extra:bar

--- a/docs/advanced-search-queries.md
+++ b/docs/advanced-search-queries.md
@@ -2,18 +2,20 @@
 
 The search query allows for more fine-grained control over the search results. The following operators are supported:
 
-| Operator                             | Short | Description                                                                     |
-|--------------------------------------|-------|---------------------------------------------------------------------------------|
-| `before:<date>`,`before:"<date>"`    | `b`   | Show all logs messages that occur before the specified date.                    |
-| `after:<date>`,`after:"<date>"`      | `a`   | Show all logs messages that occur after the specified date.                     |
-| `severity:<pipe-separated-string>`   | `s`   | Show all logs messages that match the given severity/severities.                |
-| `channel:<pipe-separated-string>`    | `c`   | Show all logs messages that match the given channel(s).                         |
-| `after:<date>`,`after:"<date>"`      | `a`   | Show all logs messages that occur after the specified date.                     |
-| `exclude:<word>`,`exclude:"<words>"` | `-`   | Exclude the specific sentence from the results. Can be specified multiple times |
+| Operator                                    | Short | Description                                                                     |
+|---------------------------------------------|-------|---------------------------------------------------------------------------------|
+| `before:<date>`,`before:"<date>"`           | `b`   | Show all logs messages that occur before the specified date.                    |
+| `after:<date>`,`after:"<date>"`             | `a`   | Show all logs messages that occur after the specified date.                     |
+| `severity:<pipe-separated-string>`          | `s`   | Show all logs messages that match the given severity/severities.                |
+| `channel:<pipe-separated-string>`           | `c`   | Show all logs messages that match the given channel(s).                         |
+| `after:<date>`,`after:"<date>"`             | `a`   | Show all logs messages that occur after the specified date.                     |
+| `exclude:<word>`,`exclude:"<words>"`        | `-`   | Exclude the specific sentence from the results. Can be specified multiple times |
+| `context:<string>`, `context:<key>=<value>` |       | Show all logs messages that match the given context.                            |
+| `extra:<string>`, `extra:<key>=<value>`     |       | Show all logs messages that match the given extra.                              |
 
 ## Example
 
-Search all log entries between `2020-01-01` and `2020-01-31`, for severity `warning` or `error`, in channel `app` 
+Search all log entries between `2020-01-01` and `2020-01-31`, for severity `warning` or `error`, in channel `app`
 excluding all entries that contain the word `"Controller"` and must include `"Exception"`.
 
 ```text
@@ -39,4 +41,18 @@ word.
 
 ```text
 before:"2020-01-31 23:59:59" after:"2020-01-01 00:00:00" exclude:"new IndexController" "Failed to read"
+```
+
+### Searching context or extra
+
+```text
+context:foo
+extra:bar
+```
+
+### Searching specific array key-values in context or extra:
+```text 
+context:userId=123
+context:request.uri=/api/v1/users
+extra:trace_id=12345ab
 ```

--- a/src/Entity/Expression/KeyValueTerm.php
+++ b/src/Entity/Expression/KeyValueTerm.php
@@ -1,0 +1,18 @@
+<?php
+declare(strict_types=1);
+
+namespace FD\LogViewer\Entity\Expression;
+
+class KeyValueTerm implements TermInterface
+{
+    public const TYPE_CONTEXT = 'context';
+    public const TYPE_EXTRA   = 'extra';
+
+    /**
+     * @param self::TYPE_*  $type
+     * @param string[]|null $keys
+     */
+    public function __construct(public readonly string $type, public readonly ?array $keys, public readonly string $value)
+    {
+    }
+}

--- a/src/Entity/Expression/KeyValueTerm.php
+++ b/src/Entity/Expression/KeyValueTerm.php
@@ -9,6 +9,7 @@ class KeyValueTerm implements TermInterface
     public const TYPE_EXTRA   = 'extra';
 
     /**
+     * @codeCoverageIgnore Simple DTO
      * @param self::TYPE_*  $type
      * @param string[]|null $keys
      */

--- a/src/Reader/String/StringReader.php
+++ b/src/Reader/String/StringReader.php
@@ -15,7 +15,7 @@ class StringReader
         $this->length = strlen($this->string);
     }
 
-    public function get(): string
+    public function char(): string
     {
         return $this->string[$this->position];
     }
@@ -48,7 +48,7 @@ class StringReader
      */
     public function skip(array $chars): self
     {
-        while ($this->eol() === false && in_array($this->get(), $chars, true)) {
+        while ($this->eol() === false && in_array($this->char(), $chars, true)) {
             $this->next();
         }
 
@@ -72,6 +72,7 @@ class StringReader
 
     /**
      * True if the end of line is reached
+     * @phpstan-impure
      */
     public function eol(): bool
     {

--- a/src/Resources/config/services.php
+++ b/src/Resources/config/services.php
@@ -37,6 +37,7 @@ use FD\LogViewer\Service\Matcher\SeverityTermMatcher;
 use FD\LogViewer\Service\Matcher\WordTermMatcher;
 use FD\LogViewer\Service\Parser\DateParser;
 use FD\LogViewer\Service\Parser\ExpressionParser;
+use FD\LogViewer\Service\Parser\KeyValueParser;
 use FD\LogViewer\Service\Parser\QuotedStringParser;
 use FD\LogViewer\Service\Parser\StringParser;
 use FD\LogViewer\Service\Parser\TermParser;
@@ -47,6 +48,7 @@ use FD\LogViewer\Util\Clock;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
 use function Symfony\Component\DependencyInjection\Loader\Configurator\inline_service;
+use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
 use function Symfony\Component\DependencyInjection\Loader\Configurator\tagged_iterator;
 
 return static function (ContainerConfigurator $container): void {
@@ -73,17 +75,20 @@ return static function (ContainerConfigurator $container): void {
     $services->set(JsonManifestAssetLoader::class)
         ->arg('$manifestPath', '%kernel.project_dir%/public/bundles/fdlogviewer/.vite/manifest.json');
 
+    $services->set(StringParser::class)
+        ->arg('$quotedStringParser', inline_service(QuotedStringParser::class))
+        ->arg('$wordParser', inline_service(WordParser::class));
     $services->set(ExpressionParser::class)
         ->arg(
             '$termParser',
             inline_service(TermParser::class)
-                ->arg(
-                    '$stringParser',
-                    inline_service(StringParser::class)
-                        ->arg('$quotedStringParser', inline_service(QuotedStringParser::class))
-                        ->arg('$wordParser', inline_service(WordParser::class))
+                ->args(
+                    [
+                        service(StringParser::class),
+                        inline_service(DateParser::class),
+                        inline_service(KeyValueParser::class)->args([service(StringParser::class)])
+                    ]
                 )
-                ->arg('$dateParser', inline_service(DateParser::class))
         );
 
     $services->set(FinderFactory::class);

--- a/src/Resources/config/services.php
+++ b/src/Resources/config/services.php
@@ -31,6 +31,7 @@ use FD\LogViewer\Service\JsonManifestAssetLoader;
 use FD\LogViewer\Service\Matcher\ChannelTermMatcher;
 use FD\LogViewer\Service\Matcher\DateAfterTermMatcher;
 use FD\LogViewer\Service\Matcher\DateBeforeTermMatcher;
+use FD\LogViewer\Service\Matcher\KeyValueMatcher;
 use FD\LogViewer\Service\Matcher\LogRecordMatcher;
 use FD\LogViewer\Service\Matcher\SeverityTermMatcher;
 use FD\LogViewer\Service\Matcher\WordTermMatcher;
@@ -110,6 +111,7 @@ return static function (ContainerConfigurator $container): void {
     $services->set(DateAfterTermMatcher::class)->tag('fd.symfony.log.viewer.term_matcher');
     $services->set(SeverityTermMatcher::class)->tag('fd.symfony.log.viewer.term_matcher');
     $services->set(ChannelTermMatcher::class)->tag('fd.symfony.log.viewer.term_matcher');
+    $services->set(KeyValueMatcher::class)->tag('fd.symfony.log.viewer.term_matcher');
     $services->set(WordTermMatcher::class)->tag('fd.symfony.log.viewer.term_matcher');
     $services->set(LogRecordMatcher::class)->arg('$termMatchers', tagged_iterator('fd.symfony.log.viewer.term_matcher'));
 };

--- a/src/Service/Matcher/KeyValueMatcher.php
+++ b/src/Service/Matcher/KeyValueMatcher.php
@@ -56,10 +56,10 @@ class KeyValueMatcher implements TermMatcherInterface
 
         $value = $data;
         foreach ($keys as $key) {
-            if (is_array($value) === false || isset($data[$key]) === false) {
+            if (is_array($value) === false || isset($value[$key]) === false) {
                 return false;
             }
-            $value = $data[$key];
+            $value = $value[$key];
         }
 
         return is_scalar($value) && stripos((string)$value, $term) !== false;

--- a/src/Service/Matcher/KeyValueMatcher.php
+++ b/src/Service/Matcher/KeyValueMatcher.php
@@ -1,0 +1,67 @@
+<?php
+declare(strict_types=1);
+
+namespace FD\LogViewer\Service\Matcher;
+
+use FD\LogViewer\Entity\Expression\KeyValueTerm;
+use FD\LogViewer\Entity\Expression\TermInterface;
+use FD\LogViewer\Entity\Index\LogRecord;
+
+/**
+ * @implements TermMatcherInterface<KeyValueTerm>
+ */
+class KeyValueMatcher implements TermMatcherInterface
+{
+    public function supports(TermInterface $term): bool
+    {
+        return $term instanceof KeyValueTerm;
+    }
+
+    public function matches(TermInterface $term, LogRecord $record): bool
+    {
+        $data = $term->type === KeyValueTerm::TYPE_CONTEXT ? $record->context : $record->extra;
+
+        return $term->keys === null ? $this->matchValue($term->value, $data) : $this->matchKeysValue($term->keys, $term->value, $data);
+    }
+
+    /**
+     * @param string|array<int|string, mixed> $data
+     */
+    private function matchValue(string $term, string|array $data): bool
+    {
+        if (is_string($data)) {
+            return stripos($data, $term) !== false;
+        }
+
+        $match = false;
+        array_walk_recursive(
+            $data,
+            function ($value) use (&$match, $term) {
+                $match = $match || stripos((string)$value, $term) !== false;
+            }
+        );
+
+        return $match;
+    }
+
+    /**
+     * @param string[]                        $keys
+     * @param string|array<int|string, mixed> $data
+     */
+    private function matchKeysValue(array $keys, string $term, string|array $data): bool
+    {
+        if (is_string($data)) {
+            return stripos($data, $term) !== false;
+        }
+
+        $value = $data;
+        foreach ($keys as $key) {
+            if (is_array($value) === false || isset($data[$key]) === false) {
+                return false;
+            }
+            $value = $data[$key];
+        }
+
+        return is_scalar($value) && stripos((string)$value, $term) !== false;
+    }
+}

--- a/src/Service/Parser/ExpressionParser.php
+++ b/src/Service/Parser/ExpressionParser.php
@@ -9,11 +9,13 @@ use FD\LogViewer\Reader\String\StringReader;
 /**
  * BNF:
  * <expression> ::= <term> | <term> <expression>
- * <term> ::= <date-term> | <exclude-term> | <severity-term> | <channel-term> <string>
+ * <term> ::= <date-term> | <exclude-term> | <severity-term> | <channel-term> <string> | <context-term> | <extra-term>
  * <date-term> ::= before:<string> | af
  * <severity-term> ::= severity:<string>
  * <channel-term> ::= channel:<string>
  * <exclude-term> ::= exclude:<string>
+ * <context-term> ::= context:<string> | context:<key>=<string>
+ * <extra-term> ::= extra:<string> | extra:<key>=<string>
  * <string> ::= "<characters without unescaped double quote>" | '<characters without unescaped quote>' | <characters-without-space>
  */
 class ExpressionParser

--- a/src/Service/Parser/KeyValueParser.php
+++ b/src/Service/Parser/KeyValueParser.php
@@ -1,0 +1,44 @@
+<?php
+declare(strict_types=1);
+
+namespace FD\LogViewer\Service\Parser;
+
+use FD\LogViewer\Entity\Expression\KeyValueTerm;
+use FD\LogViewer\Reader\String\StringReader;
+
+class KeyValueParser
+{
+    public function __construct(private readonly StringParser $stringParser)
+    {
+    }
+
+    /**
+     * @phpstan-param KeyValueTerm::TYPE_* $type
+     */
+    public function parse(string $type, StringReader $string): KeyValueTerm
+    {
+        $value = $this->stringParser->parse($string, ['.', '=']);
+        if ($string->eol()) {
+            return new KeyValueTerm($type, null, $value);
+        }
+
+        $keys = [];
+        if ($string->char() === '.') {
+            $keys[] = $value;
+
+            while ($string->eol() === false || $string->char() === '=') {
+                $string->next();
+                $keys[] = $this->stringParser->parse($string, ['.', '=']);
+            }
+
+            if ($string->eol()) {
+                return new KeyValueTerm($type, null, implode('.', $keys));
+            }
+        }
+
+        // skip '='
+        $string->next();
+
+        return new KeyValueTerm($type, $keys, $this->stringParser->parse($string));
+    }
+}

--- a/src/Service/Parser/KeyValueParser.php
+++ b/src/Service/Parser/KeyValueParser.php
@@ -22,23 +22,25 @@ class KeyValueParser
             return new KeyValueTerm($type, null, $value);
         }
 
-        $keys = [];
+        $keys = [$value];
         if ($string->char() === '.') {
-            $keys[] = $value;
-
-            while ($string->eol() === false || $string->char() === '=') {
+            while ($string->eol() === false && $string->char() === '.') {
                 $string->next();
                 $keys[] = $this->stringParser->parse($string, ['.', '=']);
             }
 
-            if ($string->eol()) {
+            if ($string->char() !== '=') {
                 return new KeyValueTerm($type, null, implode('.', $keys));
             }
         }
 
-        // skip '='
-        $string->next();
+        if ($string->char() === '=') {
+            // skip =
+            $string->next();
 
-        return new KeyValueTerm($type, $keys, $this->stringParser->parse($string));
+            return new KeyValueTerm($type, $keys, $this->stringParser->parse($string));
+        }
+
+        return new KeyValueTerm($type, null, $value);
     }
 }

--- a/src/Service/Parser/QuotedStringParser.php
+++ b/src/Service/Parser/QuotedStringParser.php
@@ -15,7 +15,7 @@ class QuotedStringParser
         $result  = '';
         $escaped = false;
         for (; $string->eol() === false; $string->next()) {
-            $char = $string->get();
+            $char = $string->char();
 
             // skip the escape character
             if ($char === $escapeChar && $escaped === false) {

--- a/src/Service/Parser/StringParser.php
+++ b/src/Service/Parser/StringParser.php
@@ -11,12 +11,15 @@ class StringParser
     {
     }
 
-    public function parse(StringReader $string): string
+    /**
+     * @param string[] $stopAt
+     */
+    public function parse(StringReader $string, array $stopAt = []): string
     {
-        if (in_array($string->get(), ['"', "'"], true)) {
-            return $this->quotedStringParser->parse($string, $string->get(), '\\');
+        if (in_array($string->char(), ['"', "'"], true)) {
+            return $this->quotedStringParser->parse($string, $string->char(), '\\');
         }
 
-        return $this->wordParser->parse($string);
+        return $this->wordParser->parse($string, $stopAt);
     }
 }

--- a/src/Service/Parser/StringParser.php
+++ b/src/Service/Parser/StringParser.php
@@ -16,7 +16,7 @@ class StringParser
      */
     public function parse(StringReader $string, array $stopAt = []): string
     {
-        if (in_array($string->char(), ['"', "'"], true)) {
+        if ($string->eol() === false && in_array($string->char(), ['"', "'"], true)) {
             return $this->quotedStringParser->parse($string, $string->char(), '\\');
         }
 

--- a/src/Service/Parser/TermParser.php
+++ b/src/Service/Parser/TermParser.php
@@ -59,7 +59,7 @@ class TermParser
         }
 
         if ($string->read('extra:')) {
-            return $this->keyValueParser->parse(KeyValueTerm::TYPE_CONTEXT, $string);
+            return $this->keyValueParser->parse(KeyValueTerm::TYPE_EXTRA, $string);
         }
 
         return new WordTerm($this->stringParser->parse($string), WordTerm::TYPE_INCLUDE);

--- a/src/Service/Parser/TermParser.php
+++ b/src/Service/Parser/TermParser.php
@@ -6,6 +6,7 @@ namespace FD\LogViewer\Service\Parser;
 use FD\LogViewer\Entity\Expression\ChannelTerm;
 use FD\LogViewer\Entity\Expression\DateAfterTerm;
 use FD\LogViewer\Entity\Expression\DateBeforeTerm;
+use FD\LogViewer\Entity\Expression\KeyValueTerm;
 use FD\LogViewer\Entity\Expression\SeverityTerm;
 use FD\LogViewer\Entity\Expression\TermInterface;
 use FD\LogViewer\Entity\Expression\WordTerm;
@@ -19,8 +20,11 @@ use FD\LogViewer\Reader\String\StringReader;
  */
 class TermParser
 {
-    public function __construct(private readonly StringParser $stringParser, private readonly DateParser $dateParser)
-    {
+    public function __construct(
+        private readonly StringParser $stringParser,
+        private readonly DateParser $dateParser,
+        private readonly KeyValueParser $keyValueParser
+    ) {
     }
 
     /**
@@ -48,6 +52,14 @@ class TermParser
 
         if ($string->read('exclude:') || $string->read('-:')) {
             return new WordTerm($this->stringParser->parse($string), WordTerm::TYPE_EXCLUDE);
+        }
+
+        if ($string->read('context:')) {
+            return $this->keyValueParser->parse(KeyValueTerm::TYPE_CONTEXT, $string);
+        }
+
+        if ($string->read('extra:')) {
+            return $this->keyValueParser->parse(KeyValueTerm::TYPE_CONTEXT, $string);
         }
 
         return new WordTerm($this->stringParser->parse($string), WordTerm::TYPE_INCLUDE);

--- a/src/Service/Parser/WordParser.php
+++ b/src/Service/Parser/WordParser.php
@@ -9,12 +9,15 @@ class WordParser
 {
     public const WHITESPACE = [' ' => true, "\t" => true, "\n" => true, "\r" => true];
 
-    public function parse(StringReader $string): string
+    /**
+     * @param string[] $stopAt
+     */
+    public function parse(StringReader $string, array $stopAt = []): string
     {
         $result = '';
         for (; $string->eol() === false; $string->next()) {
-            $char = $string->get();
-            if (isset(self::WHITESPACE[$char])) {
+            $char = $string->char();
+            if (isset(self::WHITESPACE[$char]) || in_array($char, $stopAt, true)) {
                 break;
             }
             $result .= $char;

--- a/tests/Integration/Service/Parser/KeyValueParserTest.php
+++ b/tests/Integration/Service/Parser/KeyValueParserTest.php
@@ -1,0 +1,48 @@
+<?php
+declare(strict_types=1);
+
+namespace FD\LogViewer\Tests\Integration\Service\Parser;
+
+use FD\LogViewer\Entity\Expression\KeyValueTerm;
+use FD\LogViewer\Reader\String\StringReader;
+use FD\LogViewer\Service\Parser\KeyValueParser;
+use FD\LogViewer\Service\Parser\QuotedStringParser;
+use FD\LogViewer\Service\Parser\StringParser;
+use FD\LogViewer\Service\Parser\WordParser;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\TestWith;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(KeyValueParser::class)]
+class KeyValueParserTest extends TestCase
+{
+    private KeyValueParser $parser;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->parser = new KeyValueParser(new StringParser(new QuotedStringParser(), new WordParser()));
+    }
+
+    /**
+     * @param string[]|null $keys
+     */
+    #[TestWith(['foobar', null, 'foobar'])]
+    #[TestWith(['"foobar"', null, 'foobar'])]
+    #[TestWith(['"foo" "bar" ', null, 'foo'])]
+    #[TestWith(['foo.bar boo', null, 'foo.bar'])]
+    #[TestWith(['foo=bar', ['foo'], 'bar'])]
+    #[TestWith(['foo="bar"', ['foo'], 'bar'])]
+    #[TestWith(['foo="bar" baz', ['foo'], 'bar'])]
+    #[TestWith(['"foo"=bar baz', ['foo'], 'bar'])]
+    #[TestWith(['foo.bar=baz', ['foo', 'bar'], 'baz'])]
+    #[TestWith(['foo.bar=baz boo', ['foo', 'bar'], 'baz'])]
+    #[TestWith(['foo."bar"=baz boo', ['foo', 'bar'], 'baz'])]
+    public function testParseString(string $string, ?array $keys, string $value): void
+    {
+        $term = $this->parser->parse(KeyValueTerm::TYPE_CONTEXT, new StringReader($string));
+
+        static::assertSame($keys, $term->keys);
+        static::assertSame($value, $term->value);
+    }
+}

--- a/tests/Unit/Reader/String/StringReaderTest.php
+++ b/tests/Unit/Reader/String/StringReaderTest.php
@@ -14,19 +14,19 @@ class StringReaderTest extends TestCase
     {
         $string = new StringReader('Foobar  ');
 
-        static::assertSame('F', $string->get());
+        static::assertSame('F', $string->char());
         static::assertSame('Foob', $string->peek(4));
 
         $string->next();
-        static::assertSame('o', $string->get());
+        static::assertSame('o', $string->char());
         static::assertSame('ooba', $string->peek(4));
 
         $string->skip(['o']);
-        static::assertSame('b', $string->get());
+        static::assertSame('b', $string->char());
         static::assertSame('bar ', $string->peek(4));
 
         $string->skip(['b', 'a', 'r']);
-        static::assertSame(' ', $string->get());
+        static::assertSame(' ', $string->char());
 
         $string->skipWhitespace();
         static::assertTrue($string->eol());
@@ -38,6 +38,6 @@ class StringReaderTest extends TestCase
 
         static::assertFalse($string->read('baz'));
         static::assertTrue($string->read('foo'));
-        static::assertSame('b', $string->get());
+        static::assertSame('b', $string->char());
     }
 }

--- a/tests/Unit/Service/Matcher/KeyValueMatcherTest.php
+++ b/tests/Unit/Service/Matcher/KeyValueMatcherTest.php
@@ -6,6 +6,7 @@ namespace FD\LogViewer\Tests\Unit\Service\Matcher;
 use DateTimeImmutable;
 use FD\LogViewer\Entity\Expression\DateBeforeTerm;
 use FD\LogViewer\Entity\Expression\KeyValueTerm;
+use FD\LogViewer\Entity\Index\LogRecord;
 use FD\LogViewer\Service\Matcher\KeyValueMatcher;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
@@ -27,8 +28,24 @@ class KeyValueMatcherTest extends TestCase
         static::assertTrue($this->matcher->supports(new KeyValueTerm(KeyValueTerm::TYPE_CONTEXT, null, 'value')));
     }
 
-    public function testMatches(): void
+    public function testMatchesAnArrayValue(): void
     {
+        $record = new LogRecord(2000000, 'Warning', 'app', 'message', [], ['key' => 'value']);
+        $term   = new KeyValueTerm(KeyValueTerm::TYPE_EXTRA, null, 'value');
+        static::assertTrue($this->matcher->matches($term, $record));
     }
 
+    public function testMatchesAKeyValue(): void
+    {
+        $record = new LogRecord(2000000, 'Warning', 'app', 'message', [], ['key' => 'value']);
+        $term   = new KeyValueTerm(KeyValueTerm::TYPE_EXTRA, ['key'], 'value');
+        static::assertTrue($this->matcher->matches($term, $record));
+    }
+
+    public function testMatchesANestedKeyValue(): void
+    {
+        $record = new LogRecord(2000000, 'Warning', 'app', 'message', [], ['key1' => ['key2' => 'value']]);
+        $term   = new KeyValueTerm(KeyValueTerm::TYPE_EXTRA, ['key1', 'key2'], 'value');
+        static::assertTrue($this->matcher->matches($term, $record));
+    }
 }

--- a/tests/Unit/Service/Matcher/KeyValueMatcherTest.php
+++ b/tests/Unit/Service/Matcher/KeyValueMatcherTest.php
@@ -1,0 +1,34 @@
+<?php
+declare(strict_types=1);
+
+namespace FD\LogViewer\Tests\Unit\Service\Matcher;
+
+use DateTimeImmutable;
+use FD\LogViewer\Entity\Expression\DateBeforeTerm;
+use FD\LogViewer\Entity\Expression\KeyValueTerm;
+use FD\LogViewer\Service\Matcher\KeyValueMatcher;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(KeyValueMatcher::class)]
+class KeyValueMatcherTest extends TestCase
+{
+    private KeyValueMatcher $matcher;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->matcher = new KeyValueMatcher();
+    }
+
+    public function testSupports(): void
+    {
+        static::assertFalse($this->matcher->supports(new DateBeforeTerm(new DateTimeImmutable())));
+        static::assertTrue($this->matcher->supports(new KeyValueTerm(KeyValueTerm::TYPE_CONTEXT, null, 'value')));
+    }
+
+    public function testMatches(): void
+    {
+    }
+
+}

--- a/tests/Unit/Service/Matcher/KeyValueMatcherTest.php
+++ b/tests/Unit/Service/Matcher/KeyValueMatcherTest.php
@@ -10,6 +10,7 @@ use FD\LogViewer\Entity\Index\LogRecord;
 use FD\LogViewer\Service\Matcher\KeyValueMatcher;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
+use stdClass;
 
 #[CoversClass(KeyValueMatcher::class)]
 class KeyValueMatcherTest extends TestCase
@@ -35,10 +36,24 @@ class KeyValueMatcherTest extends TestCase
         static::assertTrue($this->matcher->matches($term, $record));
     }
 
+    public function testMatchesShouldSearchInStringData(): void
+    {
+        $record = new LogRecord(2000000, 'Warning', 'app', 'message', [], 'value');
+        $term   = new KeyValueTerm(KeyValueTerm::TYPE_EXTRA, null, 'val');
+        static::assertTrue($this->matcher->matches($term, $record));
+    }
+
     public function testMatchesAKeyValue(): void
     {
         $record = new LogRecord(2000000, 'Warning', 'app', 'message', [], ['key' => 'value']);
         $term   = new KeyValueTerm(KeyValueTerm::TYPE_EXTRA, ['key'], 'value');
+        static::assertTrue($this->matcher->matches($term, $record));
+    }
+
+    public function testMatchesAKeyValueWithoutArrayData(): void
+    {
+        $record = new LogRecord(2000000, 'Warning', 'app', 'message', [], 'value');
+        $term   = new KeyValueTerm(KeyValueTerm::TYPE_EXTRA, ['key'], 'val');
         static::assertTrue($this->matcher->matches($term, $record));
     }
 
@@ -47,5 +62,12 @@ class KeyValueMatcherTest extends TestCase
         $record = new LogRecord(2000000, 'Warning', 'app', 'message', [], ['key1' => ['key2' => 'value']]);
         $term   = new KeyValueTerm(KeyValueTerm::TYPE_EXTRA, ['key1', 'key2'], 'value');
         static::assertTrue($this->matcher->matches($term, $record));
+    }
+
+    public function testMatchesShouldIgnoreNonScalarValues(): void
+    {
+        $record = new LogRecord(2000000, 'Warning', 'app', 'message', [], ['key' => new stdClass()]);
+        $term   = new KeyValueTerm(KeyValueTerm::TYPE_EXTRA, ['key'], 'value');
+        static::assertFalse($this->matcher->matches($term, $record));
     }
 }

--- a/tests/Unit/Service/Matcher/KeyValueMatcherTest.php
+++ b/tests/Unit/Service/Matcher/KeyValueMatcherTest.php
@@ -70,4 +70,11 @@ class KeyValueMatcherTest extends TestCase
         $term   = new KeyValueTerm(KeyValueTerm::TYPE_EXTRA, ['key'], 'value');
         static::assertFalse($this->matcher->matches($term, $record));
     }
+
+    public function testMatchesShouldIgnoreUnmatchedKeys(): void
+    {
+        $record = new LogRecord(2000000, 'Warning', 'app', 'message', [], ['key' => 'value']);
+        $term   = new KeyValueTerm(KeyValueTerm::TYPE_EXTRA, ['foobar'], 'value');
+        static::assertFalse($this->matcher->matches($term, $record));
+    }
 }

--- a/tests/Unit/Service/Parser/TermParserTest.php
+++ b/tests/Unit/Service/Parser/TermParserTest.php
@@ -8,10 +8,12 @@ use Exception;
 use FD\LogViewer\Entity\Expression\ChannelTerm;
 use FD\LogViewer\Entity\Expression\DateAfterTerm;
 use FD\LogViewer\Entity\Expression\DateBeforeTerm;
+use FD\LogViewer\Entity\Expression\KeyValueTerm;
 use FD\LogViewer\Entity\Expression\SeverityTerm;
 use FD\LogViewer\Entity\Expression\WordTerm;
 use FD\LogViewer\Reader\String\StringReader;
 use FD\LogViewer\Service\Parser\DateParser;
+use FD\LogViewer\Service\Parser\KeyValueParser;
 use FD\LogViewer\Service\Parser\StringParser;
 use FD\LogViewer\Service\Parser\TermParser;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -23,14 +25,16 @@ class TermParserTest extends TestCase
 {
     private StringParser&MockObject $stringParser;
     private DateParser&MockObject $dateParser;
+    private KeyValueParser&MockObject $keyValueParser;
     private TermParser $parser;
 
     protected function setUp(): void
     {
         parent::setUp();
-        $this->stringParser = $this->createMock(StringParser::class);
-        $this->dateParser   = $this->createMock(DateParser::class);
-        $this->parser       = new TermParser($this->stringParser, $this->dateParser);
+        $this->stringParser   = $this->createMock(StringParser::class);
+        $this->dateParser     = $this->createMock(DateParser::class);
+        $this->keyValueParser = $this->createMock(KeyValueParser::class);
+        $this->parser         = new TermParser($this->stringParser, $this->dateParser, $this->keyValueParser);
     }
 
     /**
@@ -119,5 +123,31 @@ class TermParserTest extends TestCase
         static::assertInstanceOf(WordTerm::class, $term);
         static::assertSame('foobar', $term->string);
         static::assertSame(WordTerm::TYPE_INCLUDE, $term->type);
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function testParseContext(): void
+    {
+        $string = new StringReader("   context:key=value");
+        $term   = new KeyValueTerm('context', ['key'], 'value');
+
+        $this->keyValueParser->expects(self::once())->method('parse')->with('context', $string)->willReturn($term);
+
+        static::assertSame($term, $this->parser->parse($string));
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function testParseExtra(): void
+    {
+        $string = new StringReader("   extra:key=value");
+        $term   = new KeyValueTerm('extra', ['key'], 'value');
+
+        $this->keyValueParser->expects(self::once())->method('parse')->with('extra', $string)->willReturn($term);
+
+        static::assertSame($term, $this->parser->parse($string));
     }
 }


### PR DESCRIPTION
Add support for searching context and extra:

Supported syntax:
- `context:string`
- `context:key=value`
- `context:key1.key2=value`
- `extra:string`
- `extra:key=value`
- `extra:key1.key2=value`