### PR TITLE
Performance stats should be calculated at the end of the request

### DIFF
--- a/src/Entity/Output/LogRecordsOutput.php
+++ b/src/Entity/Output/LogRecordsOutput.php
@@ -3,14 +3,21 @@ declare(strict_types=1);
 
 namespace FD\LogViewer\Entity\Output;
 
-use FD\LogViewer\Entity\Index\LogRecordCollection;
+use FD\LogViewer\Entity\Index\LogRecord;
+use FD\LogViewer\Entity\Index\Paginator;
 use FD\LogViewer\Entity\Index\PerformanceStats;
 use JsonSerializable;
 
 class LogRecordsOutput implements JsonSerializable
 {
-    public function __construct(private readonly LogRecordCollection $recordCollection, private readonly PerformanceStats $performance)
-    {
+    /**
+     * @param LogRecord[] $records
+     */
+    public function __construct(
+        private readonly array $records,
+        private readonly ?Paginator $paginator,
+        private readonly PerformanceStats $performance
+    ) {
     }
 
     /**
@@ -19,8 +26,8 @@ class LogRecordsOutput implements JsonSerializable
     public function jsonSerialize(): array
     {
         return [
-            'logs'        => $this->recordCollection->getRecords(),
-            'paginator'   => $this->recordCollection->getPaginator(),
+            'logs'        => $this->records,
+            'paginator'   => $this->paginator,
             'performance' => $this->performance
         ];
     }

--- a/src/Service/File/LogRecordsOutputProvider.php
+++ b/src/Service/File/LogRecordsOutputProvider.php
@@ -39,14 +39,22 @@ class LogRecordsOutputProvider
         $recordIterator      = new LimitIterator($recordIterator, $logQuery->perPage);
         $logRecordCollection = new LogRecordCollection($recordIterator, null);
 
-        return new LogRecordsOutput($logRecordCollection, $this->performanceService->getPerformanceStats());
+        return new LogRecordsOutput(
+            $logRecordCollection->getRecords(),
+            $logRecordCollection->getPaginator(),
+            $this->performanceService->getPerformanceStats()
+        );
     }
 
     public function provide(LogFile $file, LogQueryDto $logQuery): LogRecordsOutput
     {
-        $config   = $file->folder->collection->config;
-        $logIndex = $this->logParserProvider->get($config->type)->getLogIndex($config, $file, $logQuery);
+        $config              = $file->folder->collection->config;
+        $logRecordCollection = $this->logParserProvider->get($config->type)->getLogIndex($config, $file, $logQuery);
 
-        return new LogRecordsOutput($logIndex, $this->performanceService->getPerformanceStats());
+        return new LogRecordsOutput(
+            $logRecordCollection->getRecords(),
+            $logRecordCollection->getPaginator(),
+            $this->performanceService->getPerformanceStats()
+        );
     }
 }

--- a/tests/Unit/Entity/Output/LogRecordsOutputTest.php
+++ b/tests/Unit/Entity/Output/LogRecordsOutputTest.php
@@ -3,9 +3,7 @@ declare(strict_types=1);
 
 namespace FD\LogViewer\Tests\Unit\Entity\Output;
 
-use ArrayIterator;
 use FD\LogViewer\Entity\Index\LogRecord;
-use FD\LogViewer\Entity\Index\LogRecordCollection;
 use FD\LogViewer\Entity\Index\Paginator;
 use FD\LogViewer\Entity\Index\PerformanceStats;
 use FD\LogViewer\Entity\Output\DirectionEnum;
@@ -18,12 +16,11 @@ class LogRecordsOutputTest extends TestCase
 {
     public function testJsonSerialize(): void
     {
-        $paginator        = new Paginator(DirectionEnum::Asc, true, true, 123);
-        $record           = new LogRecord('id', 111111, 'debug', 'request', 'message', [], []);
-        $recordCollection = new LogRecordCollection(new ArrayIterator([$record]), fn() => $paginator);
-        $performance      = $this->createMock(PerformanceStats::class);
+        $paginator   = new Paginator(DirectionEnum::Asc, true, true, 123);
+        $record      = new LogRecord('id', 111111, 'debug', 'request', 'message', [], []);
+        $performance = $this->createMock(PerformanceStats::class);
 
-        $logRecordsOutput = new LogRecordsOutput($recordCollection, $performance);
+        $logRecordsOutput = new LogRecordsOutput([$record], $paginator, $performance);
 
         static::assertSame(
             [


### PR DESCRIPTION
To have accurate memory and duration stats, calculate this at the end of the request.