### PR TITLE
Only forward specific headers in api proxy request

### DIFF
--- a/src/Service/Host/ResponseFactory.php
+++ b/src/Service/Host/ResponseFactory.php
@@ -11,11 +11,30 @@ use Throwable;
 
 class ResponseFactory
 {
+    private const ALLOWED_HEADERS = [
+        'accept-ranges',
+        'cache-control',
+        'connection',
+        'content-disposition',
+        'content-length',
+        'content-type',
+        'date',
+        'expires',
+        'last-modified',
+        'transfer-encoding',
+    ];
+
     /**
      * @throws Throwable
      */
     public function toStreamedResponse(HttpClientInterface $httpClient, ResponseInterface $httpResponse): StreamedResponse
     {
+        $headers         = array_filter(
+            $httpResponse->getHeaders(false),
+            static fn(string $header): bool => in_array(strtolower($header), self::ALLOWED_HEADERS, true),
+            ARRAY_FILTER_USE_KEY
+        );
+
         return new StreamedResponse(
             function () use ($httpClient, $httpResponse) {
                 $outputStream = fopen('php://output', 'wb');
@@ -27,7 +46,7 @@ class ResponseFactory
                 fclose($outputStream);
             },
             $httpResponse->getStatusCode(),
-            $httpResponse->getHeaders(false)
+            $headers
         );
     }
 }

--- a/tests/Unit/Service/Host/ResponseFactoryTest.php
+++ b/tests/Unit/Service/Host/ResponseFactoryTest.php
@@ -40,10 +40,15 @@ class ResponseFactoryTest extends TestCase
         })());
 
         $this->httpResponse->expects(self::once())->method('getStatusCode')->willReturn(200);
-        $this->httpResponse->expects(self::once())->method('getHeaders')->willReturn(['content-type' => 'application/json']);
+        $this->httpResponse->expects(self::once())
+            ->method('getHeaders')
+            ->willReturn(['content-type' => 'application/json', 'set-cookie' => 'cookie']);
         $this->httpClient->expects(self::once())->method('stream')->with($this->httpResponse)->willReturn($stream);
 
         $response = $this->factory->toStreamedResponse($this->httpClient, $this->httpResponse);
+
+        static::assertArrayHasKey('content-type', $response->headers->all());
+        static::assertArrayNotHasKey('set-cookie', $response->headers->all());
 
         ob_start();
         $response->sendContent();


### PR DESCRIPTION
When an api call is forwarded to a remote host, the response headers are forwarded to the calling client. However if the remote host for examples set `set-cookie` header, that interferes with the client session.