### PR TITLE
Only allow content-disposition, length and type. 

### DIFF
--- a/src/Service/Host/ResponseFactory.php
+++ b/src/Service/Host/ResponseFactory.php
@@ -12,16 +12,9 @@ use Throwable;
 class ResponseFactory
 {
     private const ALLOWED_HEADERS = [
-        'accept-ranges',
-        'cache-control',
-        'connection',
         'content-disposition',
         'content-length',
-        'content-type',
-        'date',
-        'expires',
-        'last-modified',
-        'transfer-encoding',
+        'content-type'
     ];
 
     /**


### PR DESCRIPTION
Reduce the impact the remote host has on the response.