### PR TITLE
Remove unnecessary ext-json requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,6 @@
     },
     "require": {
         "php": ">=8.1",
-        "ext-json": "*",
         "psr/clock": "^1.0",
         "symfony/config": "^6.0||^7.0",
         "symfony/dependency-injection": "^6.0||^7.0",


### PR DESCRIPTION
Solves Issue: #195

Extension is part of php core and doesn't need separate requirement

