### PR TITLE
Fix monolog line parser to avoid breaking on json with [ and { combinations

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ fd_log_viewer:
             downloadable: false
             deletable: false
             start_of_line_pattern: '/^\[\d{4}-\d{2}-\d{2}[^]]*]\s+\S+\.\S+:/'
-            log_message_pattern: '/^\[(?P<date>[^\]]+)\]\s+(?P<channel>[^\.]+)\.(?P<severity>[^:]+):\s+(?P<message>.*)\s+(?P<context>[[{].*?[\]}])\s+(?P<extra>[[{].*?[\]}])\s+$/s'
+            log_message_pattern: '/^\[(?P<date>[^\]]+)\]\s+(?P<channel>[^\.]+)\.(?P<severity>[^:]+):\s+(?P<message>.*)\s+(?P<context>(?:{.*?}|\[.*?]))\s+(?P<extra>(?:{.*?}|\[.*?]))\s+$/s'
             date_format: null
 
     hosts:

--- a/docs/configuration-reference.md
+++ b/docs/configuration-reference.md
@@ -21,7 +21,7 @@ fd_log_viewer:
             downloadable: false
             deletable: false
             start_of_line_pattern: '/^\[\d{4}-\d{2}-\d{2}[^]]*]\s+\S+\.\S+:/'
-            log_message_pattern: '/^\[(?P<date>[^\]]+)\]\s+(?P<channel>[^\.]+)\.(?P<severity>[^:]+):\s+(?P<message>.*)\s+(?P<context>[[{].*?[\]}])\s+(?P<extra>[[{].*?[\]}])\s+$/s'
+            log_message_pattern: '/^\[(?P<date>[^\]]+)\]\s+(?P<channel>[^\.]+)\.(?P<severity>[^:]+):\s+(?P<message>.*)\s+(?P<context>(?:{.*?}|\[.*?]))\s+(?P<extra>(?:{.*?}|\[.*?]))\s+$/s'
             date_format: null
 
     hosts:
@@ -172,7 +172,7 @@ This regex pattern is used to parse the log entry into the following named group
 - `extra`
 
 The default monolog regex
-pattern `/^\[(?P<date>[^\]]+)\]\s+(?P<channel>[^\.]+)\.(?P<severity>[^:]+):\s+(?P<message>.*)\s+(?P<context>[[{].*?[\]}])\s+(?P<extra>[[{].*?[\]}])\s+$/s`
+pattern `/^\[(?P<date>[^\]]+)\]\s+(?P<channel>[^\.]+)\.(?P<severity>[^:]+):\s+(?P<message>.*)\s+(?P<context>(?:{.*?}|\[.*?]))\s+(?P<extra>(?:{.*?}|\[.*?]))\s+$/s`
 matches:
 
 ```text

--- a/src/Service/File/Monolog/MonologLineParser.php
+++ b/src/Service/File/Monolog/MonologLineParser.php
@@ -16,8 +16,8 @@ class MonologLineParser implements LogLineParserInterface
         '/^\[(?P<date>[^\]]+)\]\s+' .
         '(?P<channel>[^\.]+)\.(?P<severity>[^:]+):\s+' .
         '(?P<message>.*)\s+' .
-        '(?P<context>[[{].*?[\]}])\s+' .
-        '(?P<extra>[[{].*?[\]}])\s+$/s';
+        '(?P<context>(?:{.*?}|\[.*?]))\s+' .
+        '(?P<extra>(?:{.*?}|\[.*?]))\s+$/s';
 
     private readonly string $logLinePattern;
 

--- a/tests/Unit/Service/File/Monolog/MonologLineParserTest.php
+++ b/tests/Unit/Service/File/Monolog/MonologLineParserTest.php
@@ -42,11 +42,11 @@ class MonologLineParserTest extends TestCase
             'severity' => 'DEBUG',
             'channel'  => 'app',
             'message'  => 'message',
-            'context'  => ['context' => 'context'],
-            'extra'    => ['extra' => 'extra'],
+            'context'  => ['context' => '[object]context'],
+            'extra'    => ['extra' => '[object]extra'],
         ];
 
-        $result = $this->parser->parse('[2000-01-01T00:00:00.000] app.DEBUG: message {"context":"context"} {"extra":"extra"}' . "\n");
+        $result = $this->parser->parse('[2000-01-01T00:00:00.000] app.DEBUG: message {"context":"[object]context"} {"extra":"[object]extra"}' . "\n");
         static::assertSame($expected, $result);
     }
 


### PR DESCRIPTION
MonologLineParser incorrectly parses:

```text
[2025-06-17T17:12:21.132905+02:00] app.ERROR: Failed to validate token for user 1 with token 1d6fb7274892a4e8ba70647b399c3ff851e0932bea0ef362773e617c030f3c and hostname example.com. Message: An OAuth server error was encountered that did not contain a JSON body {"exception":"[object] (UnexpectedValueException(code: 0): An OAuth server error was encountered that did not contain a JSON body at /project/vendor/league/oauth2-client/src/Provider/AbstractProvider.php:800)\n[previous exception] [object] (UnexpectedValueException(code: 0): Failed to parse JSON response: Syntax error at /project/vendor/league/oauth2-client/src/Provider/AbstractProvider.php:752)"} {"trace_id":"77fa144951d279168cb94f6d127732a2","transaction_id":"1868aedc715fb740","memory_usage":"12 MB"}
```