### PR TITLE
Add monolog logstash log support

### DIFF
--- a/dev/config/config.yml
+++ b/dev/config/config.yml
@@ -45,6 +45,12 @@ monolog:
       formatter: 'monolog.formatter.json'
       level: debug
       channels: [ "!event", "!deprecation" ]
+    logstash:
+      type: stream
+      path: "%kernel.logs_dir%/logstash/%kernel.environment%.log"
+      formatter: 'monolog.formatter.logstash'
+      level: debug
+      channels: [ "!event", "!deprecation" ]
     error:
       type: stream
       path: "%kernel.logs_dir%/error.log"
@@ -67,6 +73,13 @@ fd_log_viewer:
       name: Json monolog
       finder:
         in: "%kernel.logs_dir%/json"
+      downloadable: true
+      deletable: true
+    monolog-logstash:
+      type: monolog.logstash
+      name: Logstash monolog
+      finder:
+        in: "%kernel.logs_dir%/logstash"
       downloadable: true
       deletable: true
     error-log:

--- a/docs/configuration-reference.md
+++ b/docs/configuration-reference.md
@@ -48,12 +48,13 @@ This entry allows you to add more log file directories to the Log Viewer. Each e
 
 ### log_files.type
 
-**type**: `string` (`enum: monolog(.json)|http-access|apache-error|nginx-error|php-error-log`)
+**type**: `string` (`enum: monolog(.json|.logstash)|http-access|apache-error|nginx-error|php-error-log`)
 
 This is the type of log file that will be read.
 
 - `monolog` is the default type and will read the default monolog log files.
 - `monolog.json` will read the monolog log files that use `formatter: 'monolog.formatter.json'`.
+- `monolog.logstash` will read the monolog log files that use `formatter: 'monolog.formatter.logstash'`.
 - `http-access` will read the access log files of Apache and Nginx.
 - `apache-error` will read the error log files of Apache.
 - `nginx-error` will read the error log files of Nginx.

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -121,6 +121,12 @@ parameters:
 			path: src/Service/File/Monolog/MonologJsonParser.php
 
 		-
+			message: '#^Method FD\\LogViewer\\Service\\File\\Monolog\\MonologLogstashParser\:\:parse\(\) should return array\{date\: string, severity\: string, channel\: string, message\: string, context\: array\<int\|string, mixed\>\|string, extra\: array\<int\|string, mixed\>\|string\}\|null but returns array\{date\: mixed, severity\: mixed, channel\: mixed, message\: mixed, context\: mixed, extra\: mixed\}\.$#'
+			identifier: return.type
+			count: 1
+			path: src/Service/File/Monolog/MonologLogstashParser.php
+
+		-
 			message: '#^Binary operation "\." between ''/bundles…'' and mixed results in an error\.$#'
 			identifier: binaryOp.invalid
 			count: 1

--- a/src/Resources/config/services.php
+++ b/src/Resources/config/services.php
@@ -124,6 +124,9 @@ return static function (ContainerConfigurator $container): void {
     $services->set('fd.symfony.log.viewer.monolog_json_file_parser', MonologFileParser::class)
         ->tag('fd.symfony.log.viewer.log_file_parser', ['name' => 'monolog.json'])
         ->arg('$formatType', MonologFileParser::TYPE_JSON);
+    $services->set('fd.symfony.log.viewer.monolog_logstash_file_parser', MonologFileParser::class)
+        ->tag('fd.symfony.log.viewer.log_file_parser', ['name' => 'monolog.logstash'])
+        ->arg('$formatType', MonologFileParser::TYPE_LOGSTASH);
     $services->set(HttpAccessFileParser::class)->tag('fd.symfony.log.viewer.log_file_parser', ['name' => 'http-access']);
     $services->set(NginxErrorFileParser::class)->tag('fd.symfony.log.viewer.log_file_parser', ['name' => 'nginx-error']);
     $services->set(ApacheErrorFileParser::class)->tag('fd.symfony.log.viewer.log_file_parser', ['name' => 'apache-error']);

--- a/src/Service/File/Monolog/MonologFileParser.php
+++ b/src/Service/File/Monolog/MonologFileParser.php
@@ -16,6 +16,7 @@ class MonologFileParser implements LogFileParserInterface
 {
     public const TYPE_LINE = 'line';
     public const TYPE_JSON = 'json';
+    public const TYPE_LOGSTASH = 'logstash';
 
     /**
      * @param self::TYPE_* $formatType
@@ -27,6 +28,7 @@ class MonologFileParser implements LogFileParserInterface
     public function getLogIndex(LogFilesConfig $config, LogFile $file, LogQueryDto $logQuery): LogRecordCollection
     {
         return match ($this->formatType) {
+            self::TYPE_LOGSTASH => $this->logParser->parse(new SplFileInfo($file->path), new MonologLogstashParser(), $config, $logQuery),
             self::TYPE_JSON => $this->logParser->parse(new SplFileInfo($file->path), new MonologJsonParser(), $config, $logQuery),
             self::TYPE_LINE => $this->logParser->parse(
                 new SplFileInfo($file->path),

--- a/src/Service/File/Monolog/MonologLogstashParser.php
+++ b/src/Service/File/Monolog/MonologLogstashParser.php
@@ -1,0 +1,40 @@
+<?php
+declare(strict_types=1);
+
+namespace FD\LogViewer\Service\File\Monolog;
+
+use FD\LogViewer\Service\File\LogLineParserInterface;
+use JsonException;
+
+class MonologLogstashParser implements LogLineParserInterface
+{
+    public function matches(string $line): int
+    {
+        return self::MATCH_START;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function parse(string $message): ?array
+    {
+        try {
+            $json = json_decode($message, true, flags: JSON_THROW_ON_ERROR);
+        } catch (JsonException) {
+            return null;
+        }
+
+        if (is_array($json) === false) {
+            return null;
+        }
+
+        return [
+            'date' => $json['@timestamp'],
+            'severity' => $json['level'],
+            'channel' => $json['channel'],
+            'message' => $json['message'],
+            'context' => $json['context'] ?? [],
+            'extra' => $json['extra'] ?? [],
+        ];
+    }
+}

--- a/tests/Unit/Service/File/Monolog/MonologFileParserTest.php
+++ b/tests/Unit/Service/File/Monolog/MonologFileParserTest.php
@@ -11,6 +11,7 @@ use FD\LogViewer\Service\File\LogParser;
 use FD\LogViewer\Service\File\Monolog\MonologFileParser;
 use FD\LogViewer\Service\File\Monolog\MonologJsonParser;
 use FD\LogViewer\Service\File\Monolog\MonologLineParser;
+use FD\LogViewer\Service\File\Monolog\MonologLogstashParser;
 use FD\LogViewer\Tests\Utility\TestEntityTrait;
 use InvalidArgumentException;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -61,6 +62,22 @@ class MonologFileParserTest extends TestCase
             ->willReturn($recordCollection);
 
         $parser = new MonologFileParser(MonologFileParser::TYPE_JSON, $this->logParser);
+        static::assertSame($recordCollection, $parser->getLogIndex($config, $file, $logQuery));
+    }
+
+    public function testGetLogIndexForLogstashParser(): void
+    {
+        $config           = $this->createLogFileConfig();
+        $logQuery         = new LogQueryDto(['identifier'], new DateTimeZone('Europe/Amsterdam'));
+        $file             = $this->createLogFile();
+        $recordCollection = new LogRecordCollection(new ArrayIterator([]), null);
+
+        $this->logParser->expects(self::once())
+            ->method('parse')
+            ->with(new SplFileInfo('path'), new MonologLogstashParser(), $config, $logQuery)
+            ->willReturn($recordCollection);
+
+        $parser = new MonologFileParser(MonologFileParser::TYPE_LOGSTASH, $this->logParser);
         static::assertSame($recordCollection, $parser->getLogIndex($config, $file, $logQuery));
     }
 

--- a/tests/Unit/Service/File/Monolog/MonologLogstashParserTest.php
+++ b/tests/Unit/Service/File/Monolog/MonologLogstashParserTest.php
@@ -1,0 +1,53 @@
+<?php
+declare(strict_types=1);
+
+namespace FD\LogViewer\Tests\Unit\Service\File\Monolog;
+
+use FD\LogViewer\Service\File\LogLineParserInterface;
+use FD\LogViewer\Service\File\Monolog\MonologLogstashParser;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(MonologLogstashParser::class)]
+class MonologLogstashParserTest extends TestCase
+{
+    private MonologLogstashParser $parser;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->parser = new MonologLogstashParser();
+    }
+
+    public function testMatches(): void
+    {
+        static::assertSame(LogLineParserInterface::MATCH_START, $this->parser->matches('line'));
+    }
+
+    public function testParseInvalidJson(): void
+    {
+        static::assertNull($this->parser->parse('invalid json'));
+    }
+
+    public function testParseNonArrayJson(): void
+    {
+        static::assertNull($this->parser->parse('"string"'));
+    }
+
+    public function testParse(): void
+    {
+        $json     = '{"@timestamp":"2021-01-01 00:00:00.000000+00:00","@version":1,' .
+            '"host":"my-host","message":"message","type":"app","channel":"app","level":"INFO",' .
+            '"monolog_level":200,"context":["context"],"extra":["extra"]}';
+
+        $expected = [
+            'date'     => '2021-01-01 00:00:00.000000+00:00',
+            'severity' => 'INFO',
+            'channel'  => 'app',
+            'message'  => 'message',
+            'context'  => ['context'],
+            'extra'    => ['extra'],
+        ];
+        static::assertSame($expected, $this->parser->parse($json));
+    }
+}


### PR DESCRIPTION
This PR adds support for Monolog Logstash format, included in Symfony monolog bundle : https://symfony.com/doc/current/logging/formatter.html