### PR TITLE
Add copy to clipboard

### DIFF
--- a/frontend/src/components/ClipboardButton.vue
+++ b/frontend/src/components/ClipboardButton.vue
@@ -1,0 +1,94 @@
+<script setup lang="ts">
+import type LogRecord from '@/models/LogRecord'
+import { formatLogRecordForClipboard } from '@/services/LogRecordClipboard'
+import { onUnmounted, ref } from 'vue'
+
+const props = defineProps<{ logRecord: LogRecord }>()
+const copyState = ref<'idle' | 'copied' | 'error'>('idle')
+const copyPending = ref(false)
+let copyResetTimer: ReturnType<typeof setTimeout> | undefined
+
+function clearCopyResetTimer(): void {
+    if (copyResetTimer === undefined) {
+        return
+    }
+
+    clearTimeout(copyResetTimer)
+    copyResetTimer = undefined
+}
+
+function scheduleCopyReset(): void {
+    clearCopyResetTimer()
+    copyResetTimer = setTimeout(() => {
+        copyState.value = 'idle'
+        copyResetTimer = undefined
+    }, 2000)
+}
+
+async function copyLogRecord(): Promise<void> {
+    if (copyPending.value) {
+        return
+    }
+
+    clearCopyResetTimer()
+    copyPending.value = true
+
+    try {
+        if (typeof navigator === 'undefined' || navigator.clipboard === undefined) {
+            throw new Error('Clipboard API unavailable')
+        }
+
+        await navigator.clipboard.writeText(formatLogRecordForClipboard(props.logRecord))
+        copyState.value = 'copied'
+    } catch(e) {
+        console.error(e);
+        copyState.value = 'error'
+    } finally {
+        copyPending.value = false
+        scheduleCopyReset()
+    }
+}
+
+function copyButtonLabel(): string {
+    if (copyState.value === 'copied') {
+        return 'Log entry copied'
+    }
+
+    if (copyState.value === 'error') {
+        return 'Copy failed'
+    }
+
+    return 'Copy log entry'
+}
+
+onUnmounted(clearCopyResetTimer)
+</script>
+
+<template>
+    <button
+        class="btn btn-sm btn-outline-secondary border-0 flex-shrink-0 slv-btn-copy"
+        type="button"
+        :aria-label="copyButtonLabel()"
+        :title="copyButtonLabel()"
+        :disabled="copyPending"
+        @click.stop="copyLogRecord"
+    >
+        <i
+            class="bi"
+            :class="{
+                'bi-copy': copyState === 'idle',
+                'bi-check-lg text-success': copyState === 'copied',
+                'bi-x-lg text-danger': copyState === 'error'
+            }"
+            aria-hidden="true"
+        ></i>
+    </button>
+</template>
+
+<style scoped>
+.slv-btn-copy {
+    margin-left: auto;
+    --bs-btn-padding-y: 0.125rem;
+    --bs-btn-padding-x: 0.375rem;
+}
+</style>

--- a/frontend/src/components/ClipboardButton.vue
+++ b/frontend/src/components/ClipboardButton.vue
@@ -6,6 +6,8 @@ import { onUnmounted, ref } from 'vue'
 const props = defineProps<{ logRecord: LogRecord }>()
 const copyState = ref<'idle' | 'copied' | 'error'>('idle')
 const copyPending = ref(false)
+const clipboardAvailable =
+    typeof window !== 'undefined' && window.isSecureContext && navigator.clipboard !== undefined
 let copyResetTimer: ReturnType<typeof setTimeout> | undefined
 
 function clearCopyResetTimer(): void {
@@ -26,7 +28,7 @@ function scheduleCopyReset(): void {
 }
 
 async function copyLogRecord(): Promise<void> {
-    if (copyPending.value) {
+    if (copyPending.value || !clipboardAvailable) {
         return
     }
 
@@ -34,14 +36,9 @@ async function copyLogRecord(): Promise<void> {
     copyPending.value = true
 
     try {
-        if (typeof navigator === 'undefined' || navigator.clipboard === undefined) {
-            throw new Error('Clipboard API unavailable')
-        }
-
         await navigator.clipboard.writeText(formatLogRecordForClipboard(props.logRecord))
         copyState.value = 'copied'
     } catch {
-        alert('Copy to clipboard API unavailable');
         copyState.value = 'error'
     } finally {
         copyPending.value = false
@@ -66,6 +63,7 @@ onUnmounted(clearCopyResetTimer)
 
 <template>
     <button
+        v-if="clipboardAvailable"
         class="btn btn-sm btn-outline-secondary border-0 flex-shrink-0 slv-btn-copy"
         type="button"
         :aria-label="copyButtonLabel()"

--- a/frontend/src/components/ClipboardButton.vue
+++ b/frontend/src/components/ClipboardButton.vue
@@ -40,8 +40,8 @@ async function copyLogRecord(): Promise<void> {
 
         await navigator.clipboard.writeText(formatLogRecordForClipboard(props.logRecord))
         copyState.value = 'copied'
-    } catch(e) {
-        console.error(e);
+    } catch {
+        alert('Copy to clipboard API unavailable');
         copyState.value = 'error'
     } finally {
         copyPending.value = false

--- a/frontend/src/components/LogRecord.vue
+++ b/frontend/src/components/LogRecord.vue
@@ -1,48 +1,88 @@
 <script setup lang="ts">
-import JsonData from '@/components/json/JsonData.vue';
-import {nl2br, escapeHtml} from '@/services/Strings.ts';
-import type LogRecord from '@/models/LogRecord';
-import {isEmptyJson, prettyFormatJson} from '@/services/JsonFormatter';
-import {ref} from 'vue';
+import ClipboardButton from '@/components/ClipboardButton.vue'
+import JsonData from '@/components/json/JsonData.vue'
+import type LogRecord from '@/models/LogRecord'
+import { nl2br, escapeHtml } from '@/services/Strings.ts'
+import { isEmptyJson, prettyFormatJson } from '@/services/JsonFormatter'
+import { ref } from 'vue'
 
-const expanded = ref(false);
-const styled   = ref(true);
-defineProps<{ logRecord: LogRecord }>()
-const emit = defineEmits(['search']);
+const expanded = ref(false)
+const styled = ref(true)
+const props = defineProps<{ logRecord: LogRecord }>()
+const emit = defineEmits(['search'])
 
 function click(value: string) {
-    emit('search', value);
+    emit('search', value)
 }
 </script>
 
 <template>
-    <div class="slv-log-record" :class="{'opacity-50': logRecord.context_line && !expanded}" :aria-expanded="expanded">
-        <div class="slv-list-link list-group-item list-group-item-action border-0 p-0"
-             :class="{ 'text-nowrap': !expanded, 'overflow-hidden': !expanded }"
-             @click="expanded = !expanded">
+    <div
+        class="slv-log-record"
+        :class="{ 'opacity-50': props.logRecord.context_line && !expanded }"
+        :aria-expanded="expanded"
+    >
+        <div
+            class="slv-list-link list-group-item list-group-item-action border-0 p-0"
+            :class="{ 'text-nowrap': !expanded, 'overflow-hidden': !expanded }"
+            @click="expanded = !expanded"
+        >
             <i class="slv-indicator bi bi-chevron-right me-1"></i>
-            <span class="pe-2 text-secondary">{{ logRecord.datetime }}</span>
-            <span class="text-primary pe-2" v-if="logRecord.channel.length > 0">{{ logRecord.channel }}</span>
-            <span :class="['pe-2', logRecord.level_class ]">{{ logRecord.level_name }}</span>
+            <span class="pe-2 text-secondary">{{ props.logRecord.datetime }}</span>
+            <span class="text-primary pe-2" v-if="props.logRecord.channel.length > 0">{{
+                props.logRecord.channel
+            }}</span>
+            <span :class="['pe-2', props.logRecord.level_class]">{{
+                props.logRecord.level_name
+            }}</span>
 
             <!-- log message -->
-            <span v-if="!expanded" v-text="logRecord.text.substring(0, 500)"></span>
-            <span v-if="expanded" v-html="nl2br(escapeHtml(logRecord.text))"></span>
+            <span
+                class="slv-log-message"
+                v-if="!expanded"
+                v-text="props.logRecord.text.substring(0, 500)"
+            ></span>
+            <span
+                class="slv-log-message"
+                v-if="expanded"
+                v-html="nl2br(escapeHtml(props.logRecord.text))"
+            ></span>
+            <clipboard-button :log-record="props.logRecord" />
         </div>
-        <div class="border-top pt-2 ps-2 mb-2 position-relative" v-bind:class="{'d-block': expanded, 'd-none': !expanded}" v-if="expanded">
-            <button class="btn btn-outline-secondary slv-btn-raw" @click="styled = !styled">{{ styled ? 'raw' : 'styled' }}</button>
-            <div v-if="!isEmptyJson(logRecord.context)">
+        <div
+            class="border-top pt-2 ps-2 mb-2 position-relative"
+            v-bind:class="{ 'd-block': expanded, 'd-none': !expanded }"
+            v-if="expanded"
+        >
+            <button class="btn btn-outline-secondary slv-btn-raw" @click="styled = !styled">
+                {{ styled ? 'raw' : 'styled' }}
+            </button>
+            <div v-if="!isEmptyJson(props.logRecord.context)">
                 <div class="fw-bold">Context:</div>
-                <json-data v-if="styled" path="context:" :data=logRecord.context @click="click"></json-data>
+                <json-data
+                    v-if="styled"
+                    path="context:"
+                    :data="props.logRecord.context"
+                    @click="click"
+                ></json-data>
                 <div v-else>
-                    <pre class="ms-0"><code>{{ prettyFormatJson(logRecord.context) }}</code></pre>
+                    <pre
+                        class="ms-0"
+                    ><code>{{ prettyFormatJson(props.logRecord.context) }}</code></pre>
                 </div>
             </div>
-            <div v-if="!isEmptyJson(logRecord.extra)">
+            <div v-if="!isEmptyJson(props.logRecord.extra)">
                 <div class="fw-bold">Extra:</div>
-                <json-data v-if="styled" path="extra:" :data=logRecord.extra @click="click"></json-data>
+                <json-data
+                    v-if="styled"
+                    path="extra:"
+                    :data="props.logRecord.extra"
+                    @click="click"
+                ></json-data>
                 <div v-else>
-                    <pre class="ms-0"><code>{{ prettyFormatJson(logRecord.extra) }}</code></pre>
+                    <pre
+                        class="ms-0"
+                    ><code>{{ prettyFormatJson(props.logRecord.extra) }}</code></pre>
                 </div>
             </div>
         </div>
@@ -60,15 +100,23 @@ function click(value: string) {
 }
 
 .slv-list-link {
+    align-items: flex-start;
     cursor: pointer;
+    display: flex;
+}
+
+.slv-log-message {
+    flex: 1 1 auto;
+    min-width: 0;
+    overflow: hidden;
 }
 
 .slv-btn-raw {
     position: absolute;
     top: 5px;
     right: 5px;
-    --bs-btn-padding-y: .25rem;
-    --bs-btn-padding-x: .5rem;
-    --bs-btn-font-size: .75rem;
+    --bs-btn-padding-y: 0.25rem;
+    --bs-btn-padding-x: 0.5rem;
+    --bs-btn-font-size: 0.75rem;
 }
 </style>

--- a/frontend/src/services/LogRecordClipboard.ts
+++ b/frontend/src/services/LogRecordClipboard.ts
@@ -1,25 +1,15 @@
 import type LogRecord from '@/models/LogRecord'
-import { prettyFormatJson } from '@/services/JsonFormatter'
-
-function isEmpty(data: LogRecord['context']): boolean {
-    if (typeof data === 'string') {
-        const value = data.trim()
-
-        return value === '' || value === '{}' || value === '[]'
-    }
-
-    return Object.keys(data).length === 0
-}
+import {isEmptyJson, prettyFormatJson} from '@/services/JsonFormatter'
 
 export function formatLogRecordForClipboard(logRecord: LogRecord): string {
     const header = `[${logRecord.datetime}] ${logRecord.channel !== '' ? `${logRecord.channel}.` : ''}${logRecord.level_name}: ${logRecord.text}`
     const sections = [header]
 
-    if (!isEmpty(logRecord.context)) {
+    if (!isEmptyJson(logRecord.context)) {
         sections.push(`Context:\n${prettyFormatJson(logRecord.context)}`)
     }
 
-    if (!isEmpty(logRecord.extra)) {
+    if (!isEmptyJson(logRecord.extra)) {
         sections.push(`Extra:\n${prettyFormatJson(logRecord.extra)}`)
     }
 

--- a/frontend/src/services/LogRecordClipboard.ts
+++ b/frontend/src/services/LogRecordClipboard.ts
@@ -1,0 +1,27 @@
+import type LogRecord from '@/models/LogRecord'
+import { prettyFormatJson } from '@/services/JsonFormatter'
+
+function isEmpty(data: LogRecord['context']): boolean {
+    if (typeof data === 'string') {
+        const value = data.trim()
+
+        return value === '' || value === '{}' || value === '[]'
+    }
+
+    return Object.keys(data).length === 0
+}
+
+export function formatLogRecordForClipboard(logRecord: LogRecord): string {
+    const header = `[${logRecord.datetime}] ${logRecord.channel !== '' ? `${logRecord.channel}.` : ''}${logRecord.level_name}: ${logRecord.text}`
+    const sections = [header]
+
+    if (!isEmpty(logRecord.context)) {
+        sections.push(`Context:\n${prettyFormatJson(logRecord.context)}`)
+    }
+
+    if (!isEmpty(logRecord.extra)) {
+        sections.push(`Extra:\n${prettyFormatJson(logRecord.extra)}`)
+    }
+
+    return sections.join('\n\n')
+}

--- a/frontend/tests/components/ClipboardButton.spec.ts
+++ b/frontend/tests/components/ClipboardButton.spec.ts
@@ -1,0 +1,98 @@
+import { mount } from '@vue/test-utils'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import ClipboardButton from '../../src/components/ClipboardButton.vue'
+import type LogRecord from '../../src/models/LogRecord'
+import { formatLogRecordForClipboard } from '../../src/services/LogRecordClipboard'
+
+const record: LogRecord = {
+    datetime: '2026-08-09 14:30:00',
+    level_name: 'Error',
+    level_class: 'text-danger',
+    channel: 'app',
+    text: 'Request failed',
+    context: { request_id: 'abc' },
+    extra: { duration_ms: 120 }
+}
+
+const mountButton = () =>
+    mount(ClipboardButton, {
+        props: { logRecord: record }
+    })
+
+describe('ClipboardButton', () => {
+    const writeText = vi.fn()
+
+    beforeEach(() => {
+        vi.useFakeTimers()
+        writeText.mockReset()
+        Object.defineProperty(navigator, 'clipboard', {
+            configurable: true,
+            value: { writeText }
+        })
+    })
+
+    afterEach(() => {
+        vi.useRealTimers()
+    })
+
+    test('copies the formatted log record and shows success feedback', async () => {
+        writeText.mockResolvedValue(undefined)
+        const wrapper = mountButton()
+
+        await wrapper.get('button').trigger('click')
+
+        expect(writeText).toHaveBeenCalledWith(formatLogRecordForClipboard(record))
+        expect(wrapper.get('button').attributes('aria-label')).toBe('Log entry copied')
+        expect(wrapper.get('i').classes()).toContain('bi-check-lg')
+        expect(wrapper.get('i').classes()).toContain('text-success')
+    })
+
+    test('shows an error state when the clipboard write fails', async () => {
+        writeText.mockRejectedValue(new Error('denied'))
+        const wrapper = mountButton()
+
+        await wrapper.get('button').trigger('click')
+
+        expect(wrapper.get('button').attributes('aria-label')).toBe('Copy failed')
+        expect(wrapper.get('i').classes()).toContain('bi-x-lg')
+        expect(wrapper.get('i').classes()).toContain('text-danger')
+    })
+
+    test('ignores another click while a copy is pending', async () => {
+        let resolveWriteText: () => void = () => undefined
+        writeText.mockImplementation(
+            () =>
+                new Promise<void>((resolve) => {
+                    resolveWriteText = resolve
+                })
+        )
+        const wrapper = mountButton()
+        const button = wrapper.get('button')
+
+        await button.trigger('click')
+        await button.trigger('click')
+
+        expect(writeText).toHaveBeenCalledTimes(1)
+        resolveWriteText()
+        await vi.waitFor(() => expect(button.attributes('aria-label')).toBe('Log entry copied'))
+    })
+
+    test('resets feedback after two seconds and allows an immediate retry', async () => {
+        writeText.mockResolvedValue(undefined)
+        const wrapper = mountButton()
+        const button = wrapper.get('button')
+
+        await button.trigger('click')
+        expect(button.attributes('aria-label')).toBe('Log entry copied')
+
+        await vi.advanceTimersByTimeAsync(1000)
+        await button.trigger('click')
+        expect(writeText).toHaveBeenCalledTimes(2)
+        expect(button.attributes('aria-label')).toBe('Log entry copied')
+
+        await vi.advanceTimersByTimeAsync(1999)
+        expect(button.attributes('aria-label')).toBe('Log entry copied')
+        await vi.advanceTimersByTimeAsync(1)
+        expect(button.attributes('aria-label')).toBe('Copy log entry')
+    })
+})

--- a/frontend/tests/components/ClipboardButton.spec.ts
+++ b/frontend/tests/components/ClipboardButton.spec.ts
@@ -25,6 +25,10 @@ describe('ClipboardButton', () => {
     beforeEach(() => {
         vi.useFakeTimers()
         writeText.mockReset()
+        Object.defineProperty(window, 'isSecureContext', {
+            configurable: true,
+            value: true
+        })
         Object.defineProperty(navigator, 'clipboard', {
             configurable: true,
             value: { writeText }
@@ -33,6 +37,16 @@ describe('ClipboardButton', () => {
 
     afterEach(() => {
         vi.useRealTimers()
+    })
+
+    test('hides the copy button outside a secure context', () => {
+        Object.defineProperty(window, 'isSecureContext', {
+            configurable: true,
+            value: false
+        })
+        const wrapper = mountButton()
+
+        expect(wrapper.find('button').exists()).toBe(false)
     })
 
     test('copies the formatted log record and shows success feedback', async () => {

--- a/frontend/tests/components/LogRecord.spec.ts
+++ b/frontend/tests/components/LogRecord.spec.ts
@@ -1,0 +1,47 @@
+import { mount } from '@vue/test-utils'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import LogRecord from '../../src/components/LogRecord.vue'
+import type LogRecordModel from '../../src/models/LogRecord'
+
+const record: LogRecordModel = {
+    datetime: '2026-08-09 14:30:00',
+    level_name: 'Error',
+    level_class: 'text-danger',
+    channel: 'app',
+    text: 'Request failed',
+    context: { request_id: 'abc' },
+    extra: { duration_ms: 120 }
+}
+
+const mountRecord = () =>
+    mount(LogRecord, {
+        props: { logRecord: record }
+    })
+
+describe('LogRecord', () => {
+    const writeText = vi.fn()
+
+    beforeEach(() => {
+        vi.useFakeTimers()
+        writeText.mockReset()
+        writeText.mockResolvedValue(undefined)
+        Object.defineProperty(navigator, 'clipboard', {
+            configurable: true,
+            value: { writeText }
+        })
+    })
+
+    afterEach(() => {
+        vi.useRealTimers()
+    })
+
+    test('copies through the button without toggling the row', async () => {
+        const wrapper = mountRecord()
+        const button = wrapper.get('button.slv-btn-copy')
+
+        await button.trigger('click')
+
+        expect(writeText).toHaveBeenCalledTimes(1)
+        expect(wrapper.get('.slv-log-record').attributes('aria-expanded')).toBe('false')
+    })
+})

--- a/frontend/tests/components/LogRecord.spec.ts
+++ b/frontend/tests/components/LogRecord.spec.ts
@@ -25,6 +25,10 @@ describe('LogRecord', () => {
         vi.useFakeTimers()
         writeText.mockReset()
         writeText.mockResolvedValue(undefined)
+        Object.defineProperty(window, 'isSecureContext', {
+            configurable: true,
+            value: true
+        })
         Object.defineProperty(navigator, 'clipboard', {
             configurable: true,
             value: { writeText }

--- a/frontend/tests/services/LogRecordClipboard.spec.ts
+++ b/frontend/tests/services/LogRecordClipboard.spec.ts
@@ -1,0 +1,66 @@
+import { describe, expect, test } from 'vitest'
+import { formatLogRecordForClipboard } from '../../src/services/LogRecordClipboard'
+import type LogRecord from '../../src/models/LogRecord'
+
+const record = (overrides: Partial<LogRecord> = {}): LogRecord => ({
+    datetime: '2026-08-09 14:30:00',
+    level_name: 'Error',
+    level_class: 'text-danger',
+    channel: 'app',
+    text: 'Request failed',
+    context: {},
+    extra: {},
+    ...overrides
+})
+
+describe('LogRecordClipboard', () => {
+    test('formats a complete record with readable context and extra sections', () => {
+        expect(
+            formatLogRecordForClipboard(
+                record({
+                    context: { request_id: 'abc' },
+                    extra: { duration_ms: 120 }
+                })
+            )
+        ).toBe(`[2026-08-09 14:30:00] app.Error: Request failed
+
+Context:
+{
+  "request_id": "abc"
+}
+
+Extra:
+{
+  "duration_ms": 120
+}`)
+    })
+
+    test('omits empty and whitespace-only context and extra', () => {
+        expect(formatLogRecordForClipboard(record({ context: ' \n ', extra: ' {} ' }))).toBe(
+            '[2026-08-09 14:30:00] app.Error: Request failed'
+        )
+    })
+
+    test('uses the compact header when the channel is empty', () => {
+        expect(
+            formatLogRecordForClipboard(
+                record({ channel: '', level_name: '500', text: 'GET /health' })
+            )
+        ).toBe('[2026-08-09 14:30:00] 500: GET /health')
+    })
+
+    test('preserves message whitespace and unparseable section values', () => {
+        expect(
+            formatLogRecordForClipboard(
+                record({
+                    text: '  first line\nsecond line  ',
+                    extra: '{"foo"}'
+                })
+            )
+        ).toBe(`[2026-08-09 14:30:00] app.Error:   first line
+second line  
+
+Extra:
+{"foo"}`)
+    })
+})

--- a/frontend/tests/services/LogRecordClipboard.spec.ts
+++ b/frontend/tests/services/LogRecordClipboard.spec.ts
@@ -35,9 +35,22 @@ Extra:
 }`)
     })
 
-    test('omits empty and whitespace-only context and extra', () => {
-        expect(formatLogRecordForClipboard(record({ context: ' \n ', extra: ' {} ' }))).toBe(
+    test('omits exact empty context and extra values', () => {
+        expect(formatLogRecordForClipboard(record({ context: '', extra: '{}' }))).toBe(
             '[2026-08-09 14:30:00] app.Error: Request failed'
+        )
+    })
+
+    test('preserves whitespace and non-exact empty values', () => {
+        expect(formatLogRecordForClipboard(record({ context: ' \n ', extra: ' {} ' }))).toBe(
+            `[2026-08-09 14:30:00] app.Error: Request failed
+
+Context:
+ 
+ 
+
+Extra:
+{}`
         )
     })
 


### PR DESCRIPTION
| Q               | A
|-----------------| ---
| Type            | feature
| Issue           | -
| Breaking change | no

Adds: Copy to clipboard button to log rows.

<!--
Explain what the PR does and also why. If you have parts you are not sure about, please explain.

Please check this points before submitting your PR.
 - Add test to cover the changes you made on the code.
 - If you have a change on the documentation, please link to the page that you change.
 - If you add a new feature please update the documentation in the same PR.
 - If you really need to add a breaking change, explain why it is needed. Understand that this result in a lower change to get the PR accepted.
 - Any PR need 2 approvals before it get merged, sometimes this can take some time. Please be patient.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a copy button to each log record for quickly copying formatted details.
  * Copied content includes timestamps, messages, and available context or extra information.
  * Expanded log records preserve line breaks and display context and extra data more clearly.
  * Added clear visual and accessible feedback for successful, failed, or unavailable copy actions, with automatic status reset and retry support.

* **Bug Fixes**
  * Prevented duplicate clipboard actions while a copy is in progress.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->